### PR TITLE
Allows users to set the VPC component name

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -32,3 +32,10 @@ variable "use_private_subnets" {
   description = "Use private subnets"
   default     = true
 }
+
+variable "vpc_component_name" {
+  type        = string
+  description = "VPC component name"
+  default     = "vpc"
+  nullable    = false
+}


### PR DESCRIPTION
Allow users to set the VPC component name:
* Defined input variable `vpc_component_name` with default of '`vpc`'
* Remote state uses this variable to pull in the state of the VPC
* Default behavior stays the way it was before this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option for the VPC component name, allowing users to customize it via a new variable.
* **Chores**
  * Updated configuration to use the new variable for setting the VPC component name instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->