### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -13,7 +13,7 @@ module "eks" {
 
   count = var.use_eks_security_group ? 1 : 0
 
-  component = "eks"
+  component = var.eks_component_name
 
   context = module.this.context
 }
@@ -24,7 +24,7 @@ module "dns_gbl_delegated" {
 
   count = var.use_dns_delegated ? 1 : 0
 
-  component   = "dns-delegated"
+  component   = var.dns_delegated_component_name
   environment = var.dns_gbl_delegated_environment_name
 
   context = module.this.context

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -39,3 +39,15 @@ variable "vpc_component_name" {
   default     = "vpc"
   nullable    = false
 }
+
+variable "eks_component_name" {
+  type        = string
+  description = "The name of the EKS component"
+  default     = "dns-delegated"
+}
+
+variable "dns_delegated_component_name" {
+  type        = string
+  description = "The name of the Delegated DNS component"
+  default     = "dns-delegated"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -43,7 +43,7 @@ variable "vpc_component_name" {
 variable "eks_component_name" {
   type        = string
   description = "The name of the EKS component"
-  default     = "dns-delegated"
+  default     = "eks"
 }
 
 variable "dns_delegated_component_name" {


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `eks_component_name` and `dns_delegated_component_name`.
* Variables default to preserving the behaviour of the current version.
* Remote state uses these variables to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable options for EKS and Delegated DNS component names, allowing users to customize these names via variables.
* **Chores**
  * Updated infrastructure configuration to use variable-based component names instead of fixed values for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->