### PR TITLE
feat(rds_instance): support blue green updates

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -37,7 +37,7 @@ module "rds_client_sg" {
 
 module "rds_instance" {
   source  = "cloudposse/rds/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   allocated_storage                     = var.allocated_storage
   allow_major_version_upgrade           = var.allow_major_version_upgrade
@@ -59,6 +59,7 @@ module "rds_instance" {
   db_parameter                          = var.db_parameter
   db_parameter_group                    = var.db_parameter_group
   db_subnet_group_name                  = var.db_subnet_group_name
+  blue_green_update_enabled             = var.blue_green_update_enabled
   deletion_protection                   = var.deletion_protection
   dns_zone_id                           = local.dns_zone_id != null ? local.dns_zone_id : ""
   enabled_cloudwatch_logs_exports       = var.enabled_cloudwatch_logs_exports

--- a/src/rds-variables.tf
+++ b/src/rds-variables.tf
@@ -193,6 +193,12 @@ variable "db_subnet_group_name" {
   description = "Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`"
 }
 
+variable "blue_green_update_enabled" {
+  type        = bool
+  description = "Enables low-downtime updates using RDS Blue/Green deployments. Low-downtime updates are only available for DB Instances using MySQL, MariaDB and PostgreSQL, as other engines are not supported by RDS Blue/Green deployments. They cannot be used with DB Instances with replicas."
+  default     = false
+}
+
 variable "auto_minor_version_upgrade" {
   type        = bool
   description = "Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4)"

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.vpc_component_name
 
@@ -9,7 +9,7 @@ module "vpc" {
 
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   count = var.use_eks_security_group ? 1 : 0
 
@@ -20,7 +20,7 @@ module "eks" {
 
 module "dns_gbl_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   count = var.use_dns_delegated ? 1 : 0
 


### PR DESCRIPTION
## what

- Add support for blue green updates by creating a boolean input for `blue_green_update_enabled`
- Bumps module version and remote state to `2.0.0`

## why

- Enables low-downtime updates using RDS Blue/Green deployments. Low-downtime updates are only available for DB Instances using MySQL, MariaDB and PostgreSQL, as other engines are not supported by RDS Blue/Green deployments. They cannot be used with DB Instances with replicas.

## references

- [Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#low-downtime-updates)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to enable Blue/Green updates for RDS databases. Supported for MySQL, MariaDB, and PostgreSQL engines; cannot be used with replicated database instances.

* **Chores**
  * Updated RDS module to version 1.3.0.
  * Updated remote state module instances to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->